### PR TITLE
Update to Neo4j Java Driver 4.0.1.

### DIFF
--- a/neo4j-bolt/build.gradle
+++ b/neo4j-bolt/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "org.neo4j.driver:neo4j-java-driver:4.0.0"
 
     compileOnly "io.micronaut:micronaut-management"
-    compileOnly "org.neo4j.test:neo4j-harness:4.0.0"
-	testImplementation "org.neo4j.test:neo4j-harness:3.5.14"
+    compileOnly "org.neo4j.test:neo4j-harness:3.5.16"
+    testImplementation "org.neo4j.test:neo4j-harness:3.5.16"
     testImplementation "io.micronaut:micronaut-management"
 }

--- a/neo4j-bolt/build.gradle
+++ b/neo4j-bolt/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     api "io.micronaut:micronaut-runtime:$micronautVersion"
     api "io.micronaut:micronaut-validation:$micronautVersion"
-    api "org.neo4j.driver:neo4j-java-driver:4.0.0"
+    api "org.neo4j.driver:neo4j-java-driver:4.0.1"
 
     compileOnly "io.micronaut:micronaut-management"
     compileOnly "org.neo4j.test:neo4j-harness:3.5.16"


### PR DESCRIPTION
Please see especially the commit message of the second commit why this update is a good update. The first commit restores buildability only.