### PR TITLE
build: downgrade neo4j version to 4.0.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=3.0.2.BUILD-SNAPSHOT
-neo4jDriverVersion=4.1.1
+neo4jDriverVersion=4.0.3
 neo4jVersion=3.5.16
 micronautDocsVersion=1.0.24
 micronautBuildVersion=1.1.5


### PR DESCRIPTION
I should not have upgraded the minor of Neo4j driver in a minor of the module. 