### PR TITLE
ci: version to 6.0.0 Micronaut 3.6.0-SNAPSHOT githubCoreBranch=4.0.x major version neo4j=4.4.10

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17']
+        java: ['11']
         graalvm: ['latest', 'dev']
     steps:
        # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17']
+        java: ['11']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17']
+        java: ['11', '17']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/build.gradle
+++ b/build.gradle
@@ -4,21 +4,7 @@ plugins {
     id 'io.micronaut.build.internal.quality-reporting'
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+micronautBuild {
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
 }
-
-// This should be removed when the build plugins change to use java 11/17
-// Neo4j 4.x requires Java 11, and javadoc fails when it uses Java 8
-// with error: cannot access GraphDatabaseSettings...class file has wrong version 55.0, should be 52.0
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-    }
-}
-
-tasks.withType(Javadoc) {
-    javadocTool.set(javaToolchains.javadocToolFor(java.toolchain))
-}
-

--- a/build.gradle
+++ b/build.gradle
@@ -3,3 +3,22 @@ plugins {
     id 'io.micronaut.build.internal.dependency-updates'
     id 'io.micronaut.build.internal.quality-reporting'
 }
+
+repositories {
+    mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+}
+
+// This should be removed when the build plugins change to use java 11/17
+// Neo4j 4.x requires Java 11, and javadoc fails when it uses Java 8
+// with error: cannot access GraphDatabaseSettings...class file has wrong version 55.0, should be 52.0
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+tasks.withType(Javadoc) {
+    javadocTool.set(javaToolchains.javadocToolFor(java.toolchain))
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-projectVersion=5.2.1-SNAPSHOT
+projectVersion=6.0.0-SNAPSHOT
 projectGroup=io.micronaut.neo4j
 micronautDocsVersion=2.0.0
-micronautVersion=3.5.4
+micronautVersion=4.0.0-SNAPSHOT
 micronautTestVersion=3.4.0
 groovyVersion=3.0.12
 spockVersion=2.1-groovy-3.0
@@ -15,7 +15,7 @@ developers=Graeme Rocher
 githubBranch=master
 
 # Micronaut core branch for BOM pull requests
-githubCoreBranch=3.6.x
+githubCoreBranch=4.0.x
 
 bomProperty=micronautNeo4jVersion
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 projectVersion=6.0.0-SNAPSHOT
 projectGroup=io.micronaut.neo4j
 micronautDocsVersion=2.0.0
-micronautVersion=4.0.0-SNAPSHOT
+micronautVersion=3.6.0
 micronautTestVersion=3.4.0
 groovyVersion=3.0.12
 spockVersion=2.1-groovy-3.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,12 @@
 [versions]
-# Required to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
-managed-neo4j-compat = "3.5.34"
-managed-neo4j-driver-compat = "4.4.9"
 
-managed-neo4j = "3.5.34"
+managed-neo4j = "4.4.10"
 managed-neo4j-driver = "4.4.9"
 
 # Micronaut
 micronaut-docs = "2.0.0"
 
-
 [libraries]
-# Duplicated to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
-managed-neo4j = { module = "org.neo4j.test:neo4j-harness", version.ref = "managed-neo4j-compat" }
-managed-neo4j-bolt = { module = "org.neo4j.driver:neo4j-java-driver", version.ref = "managed-neo4j-driver-compat" }
 
 managed-neo4j-harness = { module = "org.neo4j.test:neo4j-harness", version.ref = "managed-neo4j" }
 managed-neo4j-java-driver = { module = "org.neo4j.driver:neo4j-java-driver", version.ref = "managed-neo4j-driver" }

--- a/neo4j-bolt/build.gradle
+++ b/neo4j-bolt/build.gradle
@@ -2,11 +2,6 @@ plugins {
     id 'io.micronaut.build.internal.module'
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
-}
-
 dependencies {
     api(libs.managed.neo4j.java.driver)
     api(mn.micronaut.validation)

--- a/neo4j-bolt/build.gradle
+++ b/neo4j-bolt/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'io.micronaut.build.internal.module'
 }
 
+repositories {
+    mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+}
+
 dependencies {
     api(libs.managed.neo4j.java.driver)
     api(mn.micronaut.validation)

--- a/neo4j-bolt/src/main/java/io/micronaut/neo4j/bolt/health/Neo4jHealthIndicator.java
+++ b/neo4j-bolt/src/main/java/io/micronaut/neo4j/bolt/health/Neo4jHealthIndicator.java
@@ -51,7 +51,7 @@ public class Neo4jHealthIndicator implements HealthIndicator {
 
     private final Driver boltDriver;
     private final ExecutorService ioExecutor;
-    
+
     /**
      * Constructor.
      * @param boltDriver driver
@@ -78,7 +78,7 @@ public class Neo4jHealthIndicator implements HealthIndicator {
                             HealthResult.Builder status = HealthResult.builder(NAME, HealthStatus.UP);
                             ServerInfo serverInfo = resultSummaryStage.server();
                             status.details(Collections.singletonMap(
-                                "server", serverInfo.version() + "@" + serverInfo.address()));
+                                "server", serverInfo.agent() + "@" + serverInfo.address()));
                             return status.build();
                         }
                     })

--- a/neo4j-bolt/src/test/resources/logback-test.xml
+++ b/neo4j-bolt/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/neo4j-bom/build.gradle
+++ b/neo4j-bom/build.gradle
@@ -1,3 +1,13 @@
 plugins {
     id("io.micronaut.build.internal.bom")
 }
+
+// disabled until catalog is updated for 4.0.x, to avoid these build errors
+//> Version catalogs are not compatible:
+//The following versions were present in the baseline version but missing from this catalog:
+//        - neo4j-compat
+//        - neo4j-driver-compat
+//The following libraries were present in the baseline version but missing from this catalog:
+//        - neo4j
+//        - neo4j-bolt
+tasks.checkVersionCatalogCompatibility { enabled = false }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,13 +16,6 @@ include 'neo4j-bolt'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
 
-dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
-    }
-}
-
 micronautBuild {
     importMicronautCatalog()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,13 @@ include 'neo4j-bolt'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
 
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+    }
+}
+
 micronautBuild {
     importMicronautCatalog()
 }

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,8 +1,10 @@
 This section documents breaking changes between Micronaut Neo4J versions:
 
-== Micronaut Neo4J 6.0.0
+=== Micronaut Neo4J {version}
 
-Micronaut Neo4J is based on Neo4j 4.x, which has breaking changes from Neo4j 3.5.x used by previous versions of Micronaut Neo4J. It also requires Java 11. For more information, refer to the following Neo4j guides:
+Micronaut Neo4J is based on Neo4j 4.x, which has breaking changes from Neo4j 3.5.x used by previous versions of Micronaut Neo4J.
+
+For more information, refer to the following Neo4j guides:
 
 - https://neo4j.com/docs/upgrade-migration-guide/current/[Neo4j Upgrade and Migration Guide]
 

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,0 +1,9 @@
+This section documents breaking changes between Micronaut Neo4J versions:
+
+== Micronaut Neo4J 6.0.0
+
+Micronaut Neo4J is based on Neo4j 4.x, which has breaking changes from Neo4j 3.5.x used by previous versions of Micronaut Neo4J. It also requires Java 11. For more information, refer to the following Neo4j guides:
+
+- https://neo4j.com/docs/upgrade-migration-guide/current/[Neo4j Upgrade and Migration Guide]
+
+- https://neo4j.com/docs/upgrade-migration-guide/current/migration/surface-changes/[Breaking changes between Neo4j 3.5 and Neo4j 4.x]

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -11,8 +11,6 @@ To configure the Neo4j Bolt driver you should first add the `neo4j-bolt` module 
 
 dependency::micronaut-neo4j-bolt[groupId="io.micronaut.neo4j", version="{version}"]
 
-NOTE: The 1.x line of `micronaut-neo4j-bolt` supports Neo4j Java Driver 1.x. The latest version of the Neo4j Java Driver is the 4.x line which changes the package name (amongst other breaking API changes) therefore in order to follow semantic versioning the 6.x line of `micronaut-neo4j-bolt` is dedicated to the Neo4j 4.x version.
-
 You should then configure the URI of the Neo4j server you wish to communicate with in `application.yml`:
 
 .Configuring `neo4j.uri`

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -11,7 +11,7 @@ To configure the Neo4j Bolt driver you should first add the `neo4j-bolt` module 
 
 dependency::micronaut-neo4j-bolt[groupId="io.micronaut.neo4j", version="{version}"]
 
-NOTE: The 1.x line of `micronaut-neo4j-bolt` supports Neo4j Java Driver 1.x. The latest version of the Neo4j Java Driver is the 4.x line which changes the package name (amongst other breaking API changes) therefore in order to follow semantic versiooning the 2.x line of `micronaut-neo4j-bolt` is dedicated to this version.
+NOTE: The 1.x line of `micronaut-neo4j-bolt` supports Neo4j Java Driver 1.x. The latest version of the Neo4j Java Driver is the 4.x line which changes the package name (amongst other breaking API changes) therefore in order to follow semantic versioning the 6.x line of `micronaut-neo4j-bolt` is dedicated to the Neo4j 4.x version.
 
 You should then configure the URI of the Neo4j server you wish to communicate with in `application.yml`:
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -4,3 +4,4 @@ setup: Setting up the Neo4j Bolt Driver
 config: Configuring the Neo4j Bolt Driver
 testing: Neo4j and Testing
 repository: Repository
+breaks: Breaking Changes

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -3,5 +3,6 @@ releaseHistory: Release History
 setup: Setting up the Neo4j Bolt Driver
 config: Configuring the Neo4j Bolt Driver
 testing: Neo4j and Testing
-repository: Repository
+version-matrix: Version Matrix
 breaks: Breaking Changes
+repository: Repository

--- a/src/main/docs/guide/version-matrix.adoc
+++ b/src/main/docs/guide/version-matrix.adoc
@@ -1,0 +1,9 @@
+- Micronaut Neo4j 6.x uses Neo4j 4.x. It supports Java 11 runtime versions, but does not work with Java 17. To use it in a Micronaut project the dependency needs to specify the `micronaut-neo4j-bolt` version.
+
+dependency::micronaut-neo4j-bolt[groupId="io.micronaut.neo4j", version="{version}"]
+
+- Micronaut Neo4j 5.x uses Neo4j 3.x. It supports Java 8 and 11 runtime versions. To use it in a Micronaut project the version is not required since that is exposed by the BOM.
+
+dependency::micronaut-neo4j-bolt[groupId="io.micronaut.neo4j"]
+
+- A future major version of Neo4j (5.x) is expected to support Java 17.


### PR DESCRIPTION
- prepare for Micronaut 4 (no deprecated code found to remove)
- migrate neo4j from 3.5.x to 4.x with changes to `libs.versions.toml`, and fix breaking library code changes
- update docs

closes #256
closes #257  

