### PR TITLE
Neo4j upgrade to jdk17

### DIFF
--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Publish to Sonatype OSSRH
         env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Optional setup step
         env:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Publish to Sonatype Snapshots
         if: success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '17'
       - name: Set the current release version
         id: release_version
-        run: echo ::set-output name=release_version::${GITHUB_REF:17}
+        run: echo ::set-output name=release_version::${GITHUB_REF:11}
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Set the current release version
         id: release_version

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
       - name: Optional setup step
         env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@ projectVersion=6.0.0-SNAPSHOT
 projectGroup=io.micronaut.neo4j
 micronautDocsVersion=2.0.0
 micronautVersion=4.0.0-SNAPSHOT
-micronautTestVersion=3.6.2
-groovyVersion=3.0.12
-spockVersion=2.1-groovy-3.0
+micronautTestVersion=4.0.0-SNAPSHOT
+groovyVersion=4.0.6
+spockVersion=2.3-groovy-4.0
 
 title=Micronaut Neo4j
 projectDesc=Integration between Micronaut and Neo4j

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
-managed-neo4j = "4.4.11"
-managed-neo4j-driver = "5.0.0"
+managed-neo4j = "5.1.0"
+managed-neo4j-driver = "5.2.0"
 
 # Micronaut
 micronaut-docs = "2.0.0"

--- a/neo4j-bolt/build.gradle
+++ b/neo4j-bolt/build.gradle
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     api(libs.managed.neo4j.java.driver)
     api(mn.micronaut.validation)
+    api(mn.micronaut.retry)
     api(mn.reactor)
     compileOnly(libs.managed.neo4j.harness)
     compileOnly(mn.micronaut.management)
@@ -12,20 +13,4 @@ dependencies {
     testImplementation(mn.micronaut.management)
     // neo4j-harness needs this
     testRuntimeOnly(mn.javax.annotation.api)
-}
-
-test {
-    // neo4j-harness uses neo4j-unsafe, which results in the error:
-    //     java.lang.IllegalAccessException: module java.base does not open java.nio to unnamed module @13c27452
-    // The following option allows this for Java 17
-    jvmArgs = ['--add-opens', 'java.base/java.nio=ALL-UNNAMED']
-    // A comment on the Neo4j Issue 12712 https://github.com/neo4j/neo4j/issues/12712
-    // states the following allows access to all the neo4j internal classes.
-    // Current tests don't seem to need it.
-//            ,'--add-opens', 'java.base/java.lang=ALL-UNNAMED'
-//            ,'--add-opens', 'java.base/java.io=ALL-UNNAMED'
-//            ,'--add-opens', 'java.base/java.util=ALL-UNNAMED'
-//            ,'--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED'
-//            ,'--add-opens', 'java.base/sun.net.www.protocol.http=ALL-UNNAMED'
-//            ,'--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED']
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "6.0.0"
+    id("io.micronaut.build.shared.settings") version "6.0.1"
 }
 
 rootProject.name = 'neo4j-parent'

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -2,21 +2,21 @@ This section documents breaking changes between Micronaut Neo4J versions:
 
 === Micronaut Neo4J {version}
 
-Micronaut Neo4J is based on Neo4j 4.x, which has breaking changes from Neo4j 3.5.x used by previous versions of Micronaut Neo4J.
+Micronaut Neo4J is based on Neo4j 5.x, which has breaking changes from Neo4j 3.5.x used by previous versions of Micronaut Neo4J.
 
 For more information, refer to the following Neo4j guides:
 
 - https://neo4j.com/docs/upgrade-migration-guide/current/[Neo4j Upgrade and Migration Guide]
 
 - https://neo4j.com/docs/upgrade-migration-guide/current/migration/surface-changes/[Breaking changes between Neo4j 3.5 and Neo4j 4.x]
+- https://neo4j.com/docs/upgrade-migration-guide/current/version-5/migration/breaking-changes/[Breaking changes between Neo4j 4.4 and Neo4j 5.x]
 
-Neo4J Java Driver 5.0.0 adds compatibility for Java 17
+Neo4J Java Driver 5.x adds compatibility for Java 17
 
 - `GraphDatabase.routingDriver()` method – used by api:neo4j.bolt.Neo4jBoltConfiguration[] – was deprecated in Neo4J 4.4.x and removed in 5.x. As a consequence, api:neo4j.bolt.Neo4jBoltConfiguration[] now only accepts a single URI, whereas it previously accepted a list of them as an option. For more information, see the Neo4J guide on
 https://neo4j.com/docs/javascript-manual/current/client-applications/#js-initial-address-resolution[Initial Address Resolution]
 
-Neo4J Harness
-- Using the Neo4j Harness requires the following JVM args: `--add-opens java.base/java.nio=ALL-UNNAMED` to prevent the error "java.lang.IllegalAccessException: module java.base does not open java.nio to unnamed module...". For example,
+Neo4J Harness 5.x adds compatibility for Java 17
 
 .build.gradle
 [source,groovy]


### PR DESCRIPTION
- upgrade neo4j java driver to 5.2.x
- upgrade neo4j test harness to 5.0.x (resolves issues with private package access)
- groovy to 4.0.6, micronaut-test to 4.0.0-SNAPSHOT, spock to 2.3-groovy-4.0

closes #290
closes #288
closes #287
closes #285
closes #276