### PR TITLE
Start 8.2.x at 8.2.0-SNAPSHOT with core 5.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=8.1.1-SNAPSHOT
+projectVersion=8.2.0-SNAPSHOT
 projectGroup=io.micronaut.neo4j
 
 title=Micronaut Neo4j

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "5.1.13"
+micronaut = "5.2.0"
 micronaut-test = "5.0.0"
 managed-neo4j-driver = "6.2.0"
 micronaut-validation = "5.1.0"


### PR DESCRIPTION
Starts the new minor branch `8.2.x` (created from `8.1.x`) at `8.2.0-SNAPSHOT` and moves it to Micronaut core 5.2.0.

Core 5.2 may only land in a new, unreleased minor of each library, so it does not go to `8.1.x`, whose minor is already released. Tracked in micronaut-projects/micronaut-core#13110.

Switching the default and Renovate base branch to `8.2.x` is left to the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)